### PR TITLE
Remove header section and revert to simpler layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -135,27 +135,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -758,15 +737,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Removed the "Course Materials Assistant" header and subtitle from the application to restore the cleaner, older design. The theme toggle button at the top-right is preserved.

## Changes
- Removed `<header>` element from frontend/index.html
- Removed all header-related CSS rules from frontend/style.css
- Kept theme toggle functionality intact

Fixes #2

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the UI by removing the previously hidden header and its styling.
> 
> - Removes the `header` (title/subtitle) block from `frontend/index.html`
> - Deletes header-specific CSS and responsive rules from `frontend/style.css`
> - Retains existing `themeToggle` button and chat/sidebar layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 683db16baee205a588026a908d3f3cbb4de9f09a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->