### PR TITLE
Change chat text color to orange

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -264,13 +264,13 @@ body {
 
 .message.user .message-content {
     background: var(--user-message);
-    color: white;
+    color: #ff8c00;
     border-bottom-right-radius: 4px;
 }
 
 .message.assistant .message-content {
     background: var(--surface);
-    color: var(--text-primary);
+    color: #ff8c00;
     border-bottom-left-radius: 4px;
 }
 


### PR DESCRIPTION
Fixes #4

Changed the chatbot text color from white to orange (#ff8c00) for both user and assistant messages.

### Changes
- Updated user message text color in `frontend/style.css`
- Updated assistant message text color in `frontend/style.css`

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates chat message text styling for consistency.
> 
> - Sets `color: #ff8c00` for both `user` and `assistant` `.message-content` in `frontend/style.css`
> - Replaces previous text colors (`white` and `var(--text-primary)`) with orange
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e32437cee80092e370e66a305396af4849aa5162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->